### PR TITLE
Fixes & Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Enhanced features added for the Nyctermoon private server: On Nyctermoon, a cust
 - "Post" is now the default tab when you open aux.
 - Posting items now prints a chat message to confirm what item you posted with the quantity and price (as a double check to make sure you're posting only things you want to sell at the correct prices).
 - _Bugfix:_ aux no longer displays the wrong item price when clicking on items in the post window.
+- Listings posted by Marketer will not have their price data saved. So Marketer's prices will not mess with Historic Values and wont display on the tooltips of items.
+- Historic price data is now be saved cross-faction.
+- Tooltips display disenchant distribution and value by default.
+- `/aux ignore marketer` off by default - Hides all listings by the Marketer from scan results.
 
 ## Original Core Features
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# aux - WoW 1.12 AddOn (Nyctermoon Edition)
+# aux - WoW 1.12 AddOn (Microbot WoW Edition)
 
 The most advanced auction house addOn for the 1.12 client with some features more advanced than anything even on retail.
 
-Enhanced features added for the Nyctermoon private server: On Nyctermoon, a custom Marketer script will buy any item at white or better quality for 2x the vendor price if listed for 24 hours on the AH, which is the primary way to make gold on the server. These changes add some quality of life features by building on the default tweaked Aux addon posted in the Nyctermoon discord server so that it's easier to quickly post items from your inventory for the 2x vendor default (which is what all items are initially set at) and to hide or unhide items from the posting list.
+Enhanced features added for the Microbot WoW private server: On Microbot WoW, a custom Marketer script will buy any item at white or better quality for 2x the vendor price if listed for 24 hours on the AH, which is the primary way to make gold on the server. These changes add some quality of life features by building on the default tweaked Aux addon posted in the Microbot WoW discord server so that it's easier to quickly post items from your inventory for the 2x vendor default (which is what all items are initially set at) and to hide or unhide items from the posting list.
 
-## Custom Added Features for Nyctermoon
+## Custom Added Features for Microbot WoW
 
 - **Ctrl + Left Click** on an item in the posting list will post it with default 2x vendor price settings for 24hr auction time.
 - **Shift + Left Click** on an item in the posting list will hide or unhide it.

--- a/aux-addon.lua
+++ b/aux-addon.lua
@@ -38,7 +38,7 @@ do
 			for _, f in handlers do f() end
 		elseif event == 'PLAYER_LOGIN' then
 			for _, f in handlers2 do f() end
-			print('loaded - /aux')
+			--print('loaded - /aux')
 		else
 			_M[event]()
 		end
@@ -56,6 +56,7 @@ function handle.LOAD()
     M.account_data = assign(aux.account, {
         scale = 1,
         ignore_owner = true,
+        ignore_marketer = false,
         crafting_cost = true,
         post_bid = false,
         post_duration = post.DURATION_24,
@@ -74,8 +75,8 @@ function handle.LOAD()
                 merchant_sell = false,
                 merchant_buy = false,
                 daily = false,
-                disenchant_value = false,
-                disenchant_distribution = false,
+                disenchant_value = true,
+                disenchant_distribution = true,
             }
         })
     end
@@ -92,6 +93,9 @@ end
 
 function handle.LOAD2()
     local key = format('%s|%s', GetCVar'realmName', UnitFactionGroup'player')
+	if GetCVar'realmName' == 'Microbot Vanilla' then
+		key = format('%s|%s', GetCVar'realmName', 'Horde')
+	end
     aux.faction[key] = aux.faction[key] or {}
     M.faction_data = assign(aux.faction[key], {
         history = {},

--- a/core/scan.lua
+++ b/core/scan.lua
@@ -140,12 +140,15 @@ function scan_page(i)
 
 	local auction_info = info.auction(i, get_state().params.type)
 	if auction_info and (auction_info.owner or get_state().params.ignore_owner or aux.account_data.ignore_owner) then
+		if aux.account_data.ignore_marketer and auction_info.owner == "Marketer" then return scan_page(i + 1) end
 		auction_info.index = i
 		auction_info.page = get_state().page
 		auction_info.blizzard_query = get_query().blizzard_query
 		auction_info.query_type = get_state().params.type
 
-		history.process_auction(auction_info)
+		if auction_info.owner ~= "Marketer" then
+			history.process_auction(auction_info)
+		end
 
 		if (get_state().params.auto_buy_validator or pass)(auction_info) then
 			local send_signal, signal_received = aux.signal()

--- a/core/slash.lua
+++ b/core/slash.lua
@@ -21,6 +21,9 @@ function SlashCmdList.AUX(command)
     elseif arguments[1] == 'ignore' and arguments[2] == 'owner' then
 	    aux.account_data.ignore_owner = not aux.account_data.ignore_owner
         aux.print('ignore owner ' .. status(aux.account_data.ignore_owner))
+    elseif arguments[1] == 'ignore' and arguments[2] == 'marketer' then
+	    aux.account_data.ignore_marketer = not aux.account_data.ignore_marketer
+        aux.print('ignore marketer ' .. status(aux.account_data.ignore_marketer))
     elseif arguments[1] == 'post' and arguments[2] == 'bid' then
         aux.account_data.post_bid = not aux.account_data.post_bid
 	    aux.print('post bid ' .. status(aux.account_data.post_bid))
@@ -59,6 +62,7 @@ function SlashCmdList.AUX(command)
 		aux.print('Usage:')
 		aux.print('- scale [' .. aux.color.blue(aux.account_data.scale) .. ']')
 		aux.print('- ignore owner [' .. status(aux.account_data.ignore_owner) .. ']')
+		aux.print('- ignore marketer [' .. status(aux.account_data.ignore_marketer) .. ']')
 		aux.print('- post bid [' .. status(aux.account_data.post_bid) .. ']')
         aux.print('- post duration [' .. aux.color.blue(aux.account_data.post_duration / 60 .. 'h') .. ']')
         aux.print('- crafting cost [' .. status(aux.account_data.crafting_cost) .. ']')

--- a/frame.lua
+++ b/frame.lua
@@ -1,5 +1,6 @@
 module 'aux'
 
+local aux = require 'aux'
 local gui = require 'aux.gui'
 
 function handle.LOAD()
@@ -48,4 +49,5 @@ do
 	btn:SetScript('OnClick',function()
 		if AuctionFrame:IsVisible() then HideUIPanel(AuctionFrame) else ShowUIPanel(AuctionFrame) end
 	end)
+	blizzard_button = btn
 end

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -387,7 +387,6 @@ end
 
 function update_item(item)
 
-print("this triggered for: "..item.name)
     local settings = read_settings(item.key)
 
     item.unit_vendor_price = unit_vendor_price(item.key)

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -252,7 +252,7 @@ function post_auctions()
                     record_auction(key, stack_size, unit_start_price * stack_size, unit_buyout_price, duration_code, UnitName'player')
                     local price_string = money.to_string(unit_buyout_price * stack_size, true, nil, nil, true)
                     local stack_info = stack_size > 1 and (" x" .. stack_size) or ""
-                    aux.print(selected_item.name .. stack_info .. " listed for " .. price_string .. ".")
+                    --aux.print(selected_item.name .. stack_info .. " listed for " .. price_string .. ".")
                 end
                 update_inventory_records()
 				local same
@@ -386,6 +386,8 @@ function unit_vendor_price(item_key)
 end
 
 function update_item(item)
+
+print("this triggered for: "..item.name)
     local settings = read_settings(item.key)
 
     item.unit_vendor_price = unit_vendor_price(item.key)
@@ -438,31 +440,33 @@ function update_inventory_records()
 	    T.temp(slot)
 	    local item_info = T.temp-info.container_item(unpack(slot))
         if item_info then
-            local charge_class = item_info.charges or 0
-            if info.auctionable(item_info.tooltip, nil, true) and not item_info.lootable then
-                if not auctionable_map[item_info.item_key] then
-                    local availability = T.acquire()
-                    for i = 0, 10 do
-                        availability[i] = 0
+            if item_info.quality ~= 0 then
+                local charge_class = item_info.charges or 0
+                if info.auctionable(item_info.tooltip, nil, true) and not item_info.lootable then
+                    if not auctionable_map[item_info.item_key] then
+                        local availability = T.acquire()
+                        for i = 0, 10 do
+                            availability[i] = 0
+                        end
+                        availability[charge_class] = item_info.count
+                        auctionable_map[item_info.item_key] = T.map(
+                            'item_id', item_info.item_id,
+                            'suffix_id', item_info.suffix_id,
+                            'key', item_info.item_key,
+                            'itemstring', item_info.itemstring,
+                            'name', item_info.name,
+                            'texture', item_info.texture,
+                            'quality', item_info.quality,
+                            'aux_quantity', item_info.charges or item_info.count,
+                            'max_stack', item_info.max_stack,
+                            'max_charges', item_info.max_charges,
+                            'availability', availability
+                        )
+                    else
+                        local auctionable = auctionable_map[item_info.item_key]
+                        auctionable.availability[charge_class] = (auctionable.availability[charge_class] or 0) + item_info.count
+                        auctionable.aux_quantity = auctionable.aux_quantity + (item_info.charges or item_info.count)
                     end
-                    availability[charge_class] = item_info.count
-                    auctionable_map[item_info.item_key] = T.map(
-	                    'item_id', item_info.item_id,
-	                    'suffix_id', item_info.suffix_id,
-	                    'key', item_info.item_key,
-	                    'itemstring', item_info.itemstring,
-	                    'name', item_info.name,
-	                    'texture', item_info.texture,
-	                    'quality', item_info.quality,
-	                    'aux_quantity', item_info.charges or item_info.count,
-	                    'max_stack', item_info.max_stack,
-	                    'max_charges', item_info.max_charges,
-	                    'availability', availability
-                    )
-                else
-                    local auctionable = auctionable_map[item_info.item_key]
-                    auctionable.availability[charge_class] = (auctionable.availability[charge_class] or 0) + item_info.count
-                    auctionable.aux_quantity = auctionable.aux_quantity + (item_info.charges or item_info.count)
                 end
             end
         end


### PR DESCRIPTION
**Fixes:**
* Listings posted by Marketer will not have their price data saved. _This means that Marketer's prices will not mess with Historic Values and wont display the tooltips of items_
* Historic price data is now be saved cross-faction.

**Now on by default:**
`/aux tooltip disenchant value`
`/aux tooltip disenchant distribution`

**New command:**
`/aux ignore marketer` _off by default - Hides all listings by the Marketer from scan results._